### PR TITLE
config/dtb: Update Motorola Moto G6 (ali) config

### DIFF
--- a/config/motorola-ali.sh
+++ b/config/motorola-ali.sh
@@ -3,5 +3,7 @@
 
 OPTIONS=(-r vsn -r vsp)
 PANELS=(
-	[tianma_565_1080p_vid_v0]="tianma,tl057fvxp01"
+	[boe_565_1080p_vid_v0]="motorola,ali-panel-boe"
+	[tianma_565_1080p_vid_v0]="motorola,ali-panel-tianma"
+	# [auo_565_1080p_vid_v0]="motorola,ali-panel-auo"
 )


### PR DESCRIPTION
Update motorola ali panel names match with lk2nd and add boe panel.

AUO variant is not available in the provided dtb

Depends on https://github.com/msm8953-mainline/lk2nd/pull/68